### PR TITLE
Handle missing REDIS_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ This bot requires **Node.js 18** or later.
    GNEWS_DAILY_LIMIT=100
    NEWSAPI_THRESHOLD=10
    QUEUE_MAX=5
-   REDIS_URL=redis://localhost:6379
+  # Redis connection URL (defaults to redis://localhost:6379 if omitted)
+  REDIS_URL=redis://localhost:6379
    VOICE_SPEED=1.0
    VOICE_VOLUME=100
    ```

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,6 +1,10 @@
 // lib/storage.js
 const Redis = require('ioredis');
-const redis = new Redis(process.env.REDIS_URL);
+// Use a sensible default if REDIS_URL is not provided. When the
+// environment variable is empty ioredis attempts to connect to `/`,
+// which results in an EACCES error.
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const redis = new Redis(redisUrl);
 
 async function get(key, fallback) {
   const v = await redis.get(key);


### PR DESCRIPTION
## Summary
- clarify how to configure `REDIS_URL`
- default to `redis://localhost:6379` when no URL is provided

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68492bf5492c832088a98c67aa53ef26