### PR TITLE
Handle empty Redis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ This bot requires **Node.js 18** or later.
    NEWSAPI_DAILY_LIMIT=100
    GNEWS_DAILY_LIMIT=100
    NEWSAPI_THRESHOLD=10
-   QUEUE_MAX=5
-  # Redis connection URL (defaults to redis://localhost:6379 if omitted)
-  REDIS_URL=redis://localhost:6379
-   VOICE_SPEED=1.0
-   VOICE_VOLUME=100
-   ```
+  QUEUE_MAX=5
+ # Redis connection URL (defaults to redis://localhost:6379 if omitted)
+ REDIS_URL=redis://localhost:6379
+  VOICE_SPEED=1.0
+  VOICE_VOLUME=100
+  ```
+
+  `REDIS_URL` を空文字にすると ioredis が `/` に接続しようとして
+  `EACCES` エラーになるため、未設定にするか正しい URL を指定してください。
 
 3. Deploy slash commands:
    ```sh

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,9 +1,11 @@
 // lib/storage.js
 const Redis = require('ioredis');
-// Use a sensible default if REDIS_URL is not provided. When the
-// environment variable is empty ioredis attempts to connect to `/`,
-// which results in an EACCES error.
-const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+// Use a sensible default if REDIS_URL is missing or empty. ioredis interprets
+// an empty string as the Unix socket path `/`, which causes an EACCES error.
+const envUrl = process.env.REDIS_URL;
+const redisUrl = envUrl && envUrl.trim() !== ''
+  ? envUrl
+  : 'redis://localhost:6379';
 const redis = new Redis(redisUrl);
 
 async function get(key, fallback) {


### PR DESCRIPTION
## Summary
- improve Redis connection handling when `REDIS_URL` is blank
- document Redis URL requirement in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68492e6c9af88320912adb10d5e6b785