### PR TITLE
Update voice file download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,8 @@ WORKDIR /usr/share
 
 # MMDAgentのサンプルから「メイ」の音声ファイルを直接ダウンロードして配置
 # --no-check-certificate を追加してSSL証明書のエラーを回避
-RUN cd /usr/share && \
-    wget --no-check-certificate -O MMDAgent_Example.zip "https://ja.osdn.net/projects/mmdagent/downloads/65281/MMDAgent_Example-1.8.zip" && \
-    unzip MMDAgent_Example.zip && \
-    mkdir -p hts-voice/mei && \
-    mv MMDAgent_Example-1.8/Voice/mei/mei_normal.htsvoice hts-voice/mei/ && \
-    rm -rf MMDAgent_Example.zip MMDAgent_Example-1.8
+RUN mkdir -p /usr/share/hts-voice/tohoku-f01 && \
+    wget -O /usr/share/hts-voice/tohoku-f01/neutral.htsvoice "https://github.com/icn-lab/htsvoice-tohoku-f01/raw/master/htsvoice/tohoku-f01-neutral.htsvoice"
 
 # アプリケーションの作業ディレクトリを作成
 WORKDIR /app

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,7 @@ module.exports = {
   // Open JTalk のパスを追加
   OJ_DIC_PATH:           process.env.OJ_DIC_PATH || '/var/lib/mecab/dic/open-jtalk/naist-jdic',
   // ↓↓↓ 元の「メイ」の音声パスに戻します
-  OJ_HTS_VOICE_PATH:     process.env.OJ_HTS_VOICE_PATH || '/usr/share/hts-voice/mei/mei_normal.htsvoice',
+  OJ_HTS_VOICE_PATH:     process.env.OJ_HTS_VOICE_PATH || '/usr/share/hts-voice/tohoku-f01/neutral.htsvoice',
   
   VOICE_TONE:            Number(process.env.VOICE_TONE || 0.0),
   VOICE_QUALITY:         Number(process.env.VOICE_QUALITY || 0.55)


### PR DESCRIPTION
## Summary
- use tohoku-f01 voice file instead of Mei voice for Docker build
- update default voice file path in config

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684d89b3f7a0832098c80630a27c1131