### PR TITLE
Fix Docker voice install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM node:18-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     open-jtalk \
     open-jtalk-mecab-naist-jdic \
+    open-jtalk-hts-voice-mei \
     wget \
     unzip \
     && rm -rf /var/lib/apt/lists/*
@@ -14,13 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # /usr/shareディレクトリに移動
 WORKDIR /usr/share
 
-# MMDAgentのサンプルから「メイ」の音声ファイルを直接ダウンロードして配置
-# --no-check-certificate を追加してSSL証明書のエラーを回避
-RUN mkdir -p /usr/share/hts-voice/tohoku-f01 && \
-    wget --no-check-certificate -O htsvoice-tohoku-f01.zip "https://github.com/icn-lab/htsvoice-tohoku-f01/releases/download/v1.1.0/htsvoice-tohoku-f01-v1.1.0.zip" && \
-    unzip htsvoice-tohoku-f01.zip && \
-    mv htsvoice-tohoku-f01-v1.1.0/htsvoice/tohoku-f01-neutral/tohoku-f01-neutral.htsvoice /usr/share/hts-voice/tohoku-f01/neutral.htsvoice && \
-    rm -rf htsvoice-tohoku-f01.zip htsvoice-tohoku-f01-v1.1.0
 
 # アプリケーションの作業ディレクトリを作成
 WORKDIR /app

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,7 @@ module.exports = {
   // Open JTalk のパスを追加
   OJ_DIC_PATH:           process.env.OJ_DIC_PATH || '/var/lib/mecab/dic/open-jtalk/naist-jdic',
   // ↓↓↓ 元の「メイ」の音声パスに戻します
-  OJ_HTS_VOICE_PATH:     process.env.OJ_HTS_VOICE_PATH || '/usr/share/hts-voice/tohoku-f01/neutral.htsvoice',
+  OJ_HTS_VOICE_PATH:     process.env.OJ_HTS_VOICE_PATH || '/usr/share/hts-voice/mei/mei_normal.htsvoice',
   
   VOICE_TONE:            Number(process.env.VOICE_TONE || 0.0),
   VOICE_QUALITY:         Number(process.env.VOICE_QUALITY || 0.55)


### PR DESCRIPTION
## Summary
- download voice files using apt instead of wget
- remove obsolete download RUN command
- reset default voice path to Mei voice

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684da9fdac708320a72c9d220667d65e